### PR TITLE
Add Python binding for Vulkan : CVulkan

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ drm/kms.
 *  [Vulkano](https://github.com/tomaka/vulkano) - Safe and rich Rust wrapper around the Vulkan API. [MIT]
 *  [LWJGL](https://www.lwjgl.org/) - Lightweight Java Game Library 3 has Vulkan bindings. [BSD]
 *  [SharpVk](https://github.com/FacticiusVir/SharpVk) - C# bindings for Vulkan with Linq-to-SPIR-V & [NuGet package](https://www.nuget.org/packages/SharpVk) [MIT]
+*  [CVulkan](https://github.com/realitix/cvulkan) - Python bindings for Vulkan (C extension) generated with jinja2 template engine [MIT]
   
 ## Tools
 *  [Nsight™ Visual Studio Edition 5.2+](https://developer.nvidia.com/nvidia-nsight-visual-studio-edition).


### PR DESCRIPTION
CVulkan is a Python extension written in C.
It is generated with the jinja2 template engine and by parsing the `vk.xml` file.